### PR TITLE
Switch to radio_instance_new_with_opts() API

### DIFF
--- a/src/ril-binder-plugin.c
+++ b/src/ril-binder-plugin.c
@@ -37,21 +37,12 @@
 
 #include "ril-binder-radio.h"
 
-#define RIL_BINDER_DEFAULT_DEV  "/dev/hwbinder"
-#define RIL_BINDER_DEFAULT_NAME "slot1"
-
 static
 struct grilio_transport*
 ril_binder_transport_connect(
-    GHashTable* args)
+    GHashTable* opts)
 {
-    const char* dev = g_hash_table_lookup(args, "dev");
-    const char* name = g_hash_table_lookup(args, "name");
-
-    if (!dev) dev = RIL_BINDER_DEFAULT_DEV;
-    if (!name) name = RIL_BINDER_DEFAULT_NAME;
-    DBG("%s %s", dev, name);
-    return ril_binder_radio_new(dev, name);
+    return ril_binder_radio_new(opts);
 }
 
 static const struct ofono_ril_transport ril_binder_transport = {

--- a/src/ril-binder-radio.c
+++ b/src/ril-binder-radio.c
@@ -2916,13 +2916,12 @@ ril_binder_radio_shutdown(
 
 GRilIoTransport*
 ril_binder_radio_new(
-    const char* dev,
-    const char* name)
+    GHashTable* opts)
 {
     RilBinderRadio* self = g_object_new(RIL_TYPE_BINDER_RADIO, NULL);
     GRilIoTransport* transport = &self->parent;
 
-    self->radio = radio_instance_new(dev, name);
+    self->radio = radio_instance_new_with_opts(opts);
     if (self->radio) {
         self->radio_event_id[RADIO_EVENT_INDICATION] =
             radio_instance_add_indication_handler(self->radio, RADIO_IND_ANY,

--- a/src/ril-binder-radio.h
+++ b/src/ril-binder-radio.h
@@ -39,8 +39,7 @@
 
 GRilIoTransport*
 ril_binder_radio_new(
-    const char* dev,
-    const char* name);
+    GHashTable* opts);
 
 #endif /* RIL_BINDER_RADIO_H */
 


### PR DESCRIPTION
This API allows to configure and use custom binder interfaces derived from `android.hardware.radio@1.0` interfaces.