### PR TITLE
Fix logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,12 @@
 # on all platforms. 
 #
 
-LIB_LDPKGS = libgrilio libgbinder libgbinder-radio libglibutil gobject-2.0 glib-2.0
+PKGS = libgbinder libgbinder-radio libgrilio libglibutil gobject-2.0 glib-2.0
+
+LIB_LDPKGS = $(PKGS)
 LIB_PKGS = $(LIB_LDPKGS)
 
-PLUGIN_LDPKGS = libgrilio libglibutil
+PLUGIN_LDPKGS = $(PKGS)
 PLUGIN_PKGS = ofono $(PLUGIN_LDPKGS)
 
 #

--- a/include/ril_binder_radio.h
+++ b/include/ril_binder_radio.h
@@ -39,6 +39,9 @@ GRilIoTransport*
 ril_binder_radio_new(
     GHashTable* args);
 
+/* Logging */
+extern GLogModule ril_binder_radio_log;
+
 #endif /* RIL_BINDER_RADIO_H */
 
 /*

--- a/src/ril_binder_plugin.c
+++ b/src/ril_binder_plugin.c
@@ -35,7 +35,64 @@
 #include <ofono/ril-transport.h>
 #include <ofono/log.h>
 
+#include <radio_types.h>
+#include <gbinder_types.h>
+#include <gutil_log.h>
+
 #include "ril_binder_radio.h"
+
+/*==========================================================================*
+ * Logging
+ *==========================================================================*/
+
+static
+void
+ril_binder_plugin_binder_log_notify(
+    struct ofono_debug_desc* desc)
+{
+    gbinder_log.level = (desc->flags & OFONO_DEBUG_FLAG_PRINT) ?
+        GLOG_LEVEL_VERBOSE : GLOG_LEVEL_INHERIT;
+}
+
+static struct ofono_debug_desc gbinder_debug OFONO_DEBUG_ATTR = {
+    .name = "binder",
+    .flags = OFONO_DEBUG_FLAG_DEFAULT,
+    .notify = ril_binder_plugin_binder_log_notify
+};
+
+static
+void
+ril_binder_plugin_binder_radio_log_notify(
+    struct ofono_debug_desc* desc)
+{
+    gbinder_radio_log.level = (desc->flags & OFONO_DEBUG_FLAG_PRINT) ?
+        GLOG_LEVEL_VERBOSE : GLOG_LEVEL_INHERIT;
+}
+
+static struct ofono_debug_desc gbinder_radio_debug OFONO_DEBUG_ATTR = {
+    .name = "binder-radio",
+    .flags = OFONO_DEBUG_FLAG_DEFAULT,
+    .notify = ril_binder_plugin_binder_radio_log_notify
+};
+
+static
+void
+ril_binder_plugin_ril_binder_log_notify(
+    struct ofono_debug_desc* desc)
+{
+    ril_binder_radio_log.level = (desc->flags & OFONO_DEBUG_FLAG_PRINT) ?
+        GLOG_LEVEL_VERBOSE : GLOG_LEVEL_INHERIT;
+}
+
+static struct ofono_debug_desc grilio_binder_log_debug OFONO_DEBUG_ATTR = {
+    .name = "ril-binder",
+    .flags = OFONO_DEBUG_FLAG_DEFAULT,
+    .notify = ril_binder_plugin_ril_binder_log_notify
+};
+
+/*==========================================================================*
+ * Transport
+ *==========================================================================*/
 
 static
 struct grilio_transport*
@@ -50,6 +107,10 @@ static const struct ofono_ril_transport ril_binder_transport = {
     .api_version = OFONO_RIL_TRANSPORT_API_VERSION,
     .connect = ril_binder_transport_connect
 };
+
+/*==========================================================================*
+ * Plugin
+ *==========================================================================*/
 
 static
 int

--- a/src/ril_binder_radio.c
+++ b/src/ril_binder_radio.c
@@ -46,8 +46,12 @@
 #include <radio_instance.h>
 
 #include <gutil_idlequeue.h>
-#include <gutil_log.h>
 #include <gutil_misc.h>
+
+/* Logging */
+#define GLOG_MODULE_NAME ril_binder_radio_log
+#include <gutil_log.h>
+GLOG_MODULE_DEFINE("grilio-binder");
 
 #define RIL_BINDER_KEY_MODEM      "modem"
 #define RIL_BINDER_KEY_DEV        "dev"
@@ -100,7 +104,8 @@ G_DEFINE_TYPE(RilBinderRadio, ril_binder_radio, GRILIO_TYPE_TRANSPORT)
 
 #define PARENT_CLASS ril_binder_radio_parent_class
 
-#define DBG_(self,fmt,args...) DBG("%s" fmt, (self)->parent.log_prefix, ##args)
+#define DBG_(self,fmt,args...) \
+    GDEBUG("%s" fmt, (self)->parent.log_prefix, ##args)
 
 /*==========================================================================*
  * Utilities
@@ -3068,40 +3073,6 @@ ril_binder_radio_init_base(
     }
     return FALSE;
 }
-
-/*==========================================================================*
- * Logging
- *==========================================================================*/
-
-static
-void
-ril_binder_radio_gbinder_log_notify(
-    struct ofono_debug_desc* desc)
-{
-    gbinder_log.level = (desc->flags & OFONO_DEBUG_FLAG_PRINT) ?
-        GLOG_LEVEL_VERBOSE : GLOG_LEVEL_INHERIT;
-}
-
-static struct ofono_debug_desc gbinder_debug OFONO_DEBUG_ATTR = {
-    .name = "gbinder",
-    .flags = OFONO_DEBUG_FLAG_DEFAULT,
-    .notify = ril_binder_radio_gbinder_log_notify
-};
-
-static
-void
-ril_binder_radio_gbinder_radio_log_notify(
-    struct ofono_debug_desc* desc)
-{
-    gbinder_radio_log.level = (desc->flags & OFONO_DEBUG_FLAG_PRINT) ?
-        GLOG_LEVEL_VERBOSE : GLOG_LEVEL_INHERIT;
-}
-
-static struct ofono_debug_desc gbinder_radio_debug OFONO_DEBUG_ATTR = {
-    .name = "gbinder-radio",
-    .flags = OFONO_DEBUG_FLAG_DEFAULT,
-    .notify = ril_binder_radio_gbinder_radio_log_notify
-};
 
 /*==========================================================================*
  * Internals


### PR DESCRIPTION
ofono's `DBG` magic doesn't work in a shared library because debug descriptors end up in library's own `__debug` section and they never get enabled because ofono doesn't know anything about them.

Expose libglibutil style descriptors instead and explicitly hook them up.