### PR TITLE
Fix 64-bit build

### DIFF
--- a/libgrilio-binder.pc.in
+++ b/libgrilio-binder.pc.in
@@ -1,10 +1,10 @@
 name=grilio-binder
-libdir=/usr/lib
+libdir=@libdir@
 includedir=/usr/include
 
 Name: libgrilio-binder
 Description: Binder based transport for libgrilio
-Version: [version]
+Version: @version@
 Requires.private: glib-2.0 libgrilio libglibutil libgbinder-radio libgbinder
 Libs: -L${libdir} -l${name}
 Cflags: -I${includedir} -I${includedir}/${name}

--- a/rpm/ofono-ril-binder-plugin.spec
+++ b/rpm/ofono-ril-binder-plugin.spec
@@ -18,7 +18,7 @@ Requires: libgrilio >= %{libgrilio_version}
 BuildRequires: ofono-devel >= %{ofono_version}
 BuildRequires: pkgconfig(libgrilio) >= %{libgrilio_version}
 
-%define plugin_dir %{_libdir}/ofono/plugins
+%define plugin_dir /usr/lib/ofono/plugins
 
 %description
 This package contains ofono plugin which implements binder transport for RIL
@@ -27,11 +27,11 @@ This package contains ofono plugin which implements binder transport for RIL
 %setup -q -n %{name}-%{version}
 
 %build
-make %{_smp_mflags} KEEP_SYMBOLS=1 release pkgconfig
+make %{_smp_mflags} LIBDIR=%{_libdir} KEEP_SYMBOLS=1 release pkgconfig
 
 %install
 rm -rf %{buildroot}
-make install-dev DESTDIR=%{buildroot}
+make LIBDIR=%{_libdir} DESTDIR=%{buildroot} install-dev
 
 mkdir -p %{buildroot}/%{plugin_dir}
 %preun


### PR DESCRIPTION
Note that ofono plugins are (still) kept in `/usr/lib/ofono/plugins/`. And the plugin's .so doesn't need to be executable, fixed that too.